### PR TITLE
mirage to registry.uw.systems

### DIFF
--- a/.github/workflows/build-publish.yaml
+++ b/.github/workflows/build-publish.yaml
@@ -8,28 +8,28 @@ on:
 
 jobs:
   docker:
-    runs-on: ubuntu-latest
+    runs-on:  [self-hosted, Linux, btg-ws]
     steps:
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
+        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to DockerHub
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
-          registry: quay.io
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: registry.uw.systems
+          username: ${{ secrets.DOCKER_REGISTRY_UW_SYSTEMS_USERNAME }}
+          password: ${{ secrets.DOCKER_REGISTRY_UW_SYSTEMS_PASSWORD }}
 
       - name: Checkout
         uses: actions/checkout@v2
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           context: .
           push: true
-          tags: quay.io/utilitywarehouse/docker-wix:latest
+          tags: registry.uw.systems/btg-build/docker-wix:latest


### PR DESCRIPTION
- change the image repo from `quay.io` to `registry.uw.systems`
- also increase version numbers of the user actions